### PR TITLE
Enhance Version Filtering for Composer Registry Actions

### DIFF
--- a/src/actions/composer/registry/latest-version/actions.ts
+++ b/src/actions/composer/registry/latest-version/actions.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import semver from 'semver';
 
 interface VersionPackages {
   dist: object;
@@ -21,20 +22,28 @@ export async function packagistRegistryLookup(
       throw new Error('Package not found');
     }
 
-    console.log('Response Data', response.data);
-
     const versions: Record<string, VersionPackages> =
       response.data.package.versions;
     const versionStrings = Object.keys(versions);
 
-    console.log('Type of the version is:', typeof versions);
-    console.log('Versions are:', versionStrings);
+    // Filter only stable versions (exclude dev, alpha, beta, RC)
+    const stableVersions = versionStrings.filter((v) => {
+      // Exclude unstable versions by common keywords
+      if (/dev|alpha|beta|rc/i.test(v)) return false;
+      // Check if the version is a valid semver (strict)
+      return semver.valid(v) !== null;
+    });
 
-    const latestVersion = versionStrings[0];
+    if (stableVersions.length === 0) {
+      console.warn('No stable versions found');
+      return null;
+    }
 
-    console.log('Latest version is:', latestVersion);
+    // Sort versions from newest to oldest using semver comparison
+    stableVersions.sort(semver.rcompare);
 
-    return latestVersion;
+    // Return the highest stable version string as-is
+    return stableVersions[0];
   } catch (error) {
     console.error(`Error looking up ${packageName}:`, error);
     return null;

--- a/src/actions/composer/registry/recommended-version/actions.ts
+++ b/src/actions/composer/registry/recommended-version/actions.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import semver from 'semver';
 
 interface VersionPackages {
   dist: object;
@@ -18,32 +19,29 @@ export async function findRecommendedPackageVersion(
       `https://packagist.org/packages/${packageName}.json`,
     );
 
-    if (!response?.data.package) {
-      throw new Error('Package not found');
+    const versions = Object.keys(
+      response.data.package.versions as Record<string, VersionPackages>,
+    );
+
+    const currentCoerced = semver.coerce(current);
+    if (!currentCoerced || /^dev-|\.x-dev$/.test(current)) {
+      throw new Error(`Invalid current version: ${current}`);
     }
 
-    const versions: Record<string, VersionPackages> =
-      response.data.package.versions;
-    const versionStrings = Object.keys(versions);
+    const currentMajor = currentCoerced.major;
 
-    console.log('Type of the version is:', typeof versions);
-    console.log('Versions are:', versionStrings);
-
-    // Extract major version
-    const currentMajorVersion = current.split('.')[0];
-    const filteredVersions = versionStrings.filter((version) => {
-      const majorVersion = version.split('.')[0];
-      return majorVersion === currentMajorVersion;
+    const filtered = versions.filter((version) => {
+      const v = semver.coerce(version);
+      return (
+        v && v.major === currentMajor && !/dev|alpha|beta|RC/i.test(version)
+      );
     });
 
-    console.log('Filtered versions are:', filteredVersions);
+    const recommended = filtered.sort((a, b) =>
+      semver.rcompare(semver.coerce(a)!, semver.coerce(b)!),
+    )[0];
 
-    // Get the latest recommended version
-    const recommendedVersion = filteredVersions[0];
-
-    console.log('Next version is:', recommendedVersion);
-
-    return recommendedVersion || current;
+    return recommended || null;
   } catch (error) {
     console.error(`Error looking up ${packageName}:`, error);
     return null;


### PR DESCRIPTION
**Summary:**
This PR improves version filtering logic in the Composer registry actions to ensure only valid stable versions are considered. It refines the filtering to exclude unstable versions (dev, alpha, beta, RC) and only includes versions that comply with strict semantic versioning (semver). This enhancement ensures more accurate selection of the latest and recommended package versions.

**Details:**

* Updated `packagistRegistryLookup` to:

  * Filter out unstable versions using regex.
  * Validate versions using `semver.valid`.
  * Sort stable versions with `semver.rcompare` to identify the latest stable version.

* Updated `findRecommendedPackageVersion` to:

  * Coerce and validate the current version with `semver.coerce`.
  * Filter available versions to those matching the current major version and exclude unstable releases.
  * Sort filtered versions by semver and pick the latest stable recommended version.

**Files changed:**

* `src/actions/composer/registry/latest-version/actions.ts`
* `src/actions/composer/registry/recommended-version/actions.ts`